### PR TITLE
Add blank value to X-Forwarded-Host header to prevent client-supplied values from being passed to upstream app servers

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,8 +38,10 @@ class nginx::params {
 
   $nx_proxy_redirect          = off
   $nx_proxy_set_header        = [
-    'Host $host', 'X-Real-IP $remote_addr',
+    'Host $host',
+    'X-Real-IP $remote_addr',
     'X-Forwarded-For $proxy_add_x_forwarded_for',
+    'X-Forwarded-Host ""'
   ]
 
   $nx_client_body_temp_path   = "${nx_run_dir}/client_body_temp"


### PR DESCRIPTION
Reference https://sprint.ly/product/2322/item/10803
